### PR TITLE
Fail-over to copying files instead of linking

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,11 @@ Concat.prototype.write = function (readTree, destDir) {
     var concatenatedOutputHash = crypto.createHash('md5').update(concatenatedOutput).digest('hex')
     var cacheDir = self.getCacheDir()
     if (concatenatedOutputHash === self.cachedConcatenatedOutputHash) {
-      fs.linkSync(path.join(cacheDir, "cached-output"), path.join(destDir, self.outputFile));
+      try {
+        fs.linkSync(path.join(cacheDir, "cached-output"), path.join(destDir, self.outputFile));
+      } catch (error) {
+        fs.writeFileSync(path.join(destDir, self.outputFile), fs.readFileSync(path.join(cacheDir, "cached-output")));
+      }
     } else {
       fs.writeFileSync(path.join(destDir, self.outputFile), concatenatedOutput)
       fs.writeFileSync(path.join(cacheDir, "cached-output"), concatenatedOutput)


### PR DESCRIPTION
This is slower - but required when running in VMs (like VirtualBox, VMware) using docker containers.  The docker containers don't allow hard links.  This is a similar technique as that which is used in broccoli-caching-writer.

This should fix https://github.com/rlivsey/broccoli-concat/issues/30 and probably https://github.com/rlivsey/broccoli-concat/issues/33 