### PR TITLE
Provide better error messages when required options aren't provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,14 @@ Concat.prototype.write = function (readTree, destDir) {
     if (self.header) {
       output.push(self.header)
     }
+    
+    if (!self.inputFiles) {
+      throw new Error("inputFiles must be provided for broccoli-concat");
+    }
+
+    if (!self.outputFile) {
+      throw new Error("outputFile must be provided for broccoli-concat");
+    }
 
     // When we are done compiling, we replace self.cache with newCache, so that
     // unused cache entries are garbage-collected

--- a/tests/index.js
+++ b/tests/index.js
@@ -42,6 +42,38 @@ describe('broccoli-concat', function(){
 
     expect(fs.readdirSync('tmp')).to.eql(initialTmpContents);
   })
+  
+  describe('with no inputFiles', function() {
+    it('throws an error', function() {
+      var sourcePath = 'tests/fixtures'
+      var tree = concat(sourcePath, {
+        outputFile: '/out.js'
+      })
+      
+      builder = new broccoli.Builder(tree);
+      return builder.build().then(function(results) {
+        expect().fail("Passing no inputFiles did not throw any error")
+      }, function(error) {
+        expect(error).to.match(/inputFiles must be provided/)
+      })
+    })
+  })
+  
+  describe('with no outputFile', function() {
+    it('throws an error', function() {
+      var sourcePath = 'tests/fixtures'
+      var tree = concat(sourcePath, {
+        inputFiles: ['*.js']
+      })
+      
+      builder = new broccoli.Builder(tree);
+      return builder.build().then(function(results) {
+        expect().fail("Passing no outputFile did not throw any error")
+      }, function(error) {
+        expect(error).to.match(/outputFile must be provided/)
+      })
+    })
+  })
 
   describe('with defaults', function(){
     it('joins contents together with a newline', function(){


### PR DESCRIPTION
I just wasted quite a bit of time trying to figure out what `TypeError: Cannot read property '0' of undefined` meant.  It turned out I had forgotten to provide `outputFile` in my options to broccoli-concat.

This patch provides a clearer error message if others make the same mistake.